### PR TITLE
Add a Wasm execution budget (fuel or epoch interruption)

### DIFF
--- a/WasmTimeDriver/WasmVM.cs
+++ b/WasmTimeDriver/WasmVM.cs
@@ -20,7 +20,45 @@ namespace WasmTimeDriver
                 // .WithCraneliftDebugVerifier(true)
                 .WithOptimizationLevel(0)
                 .WithGc(true)
+                .WithFuelConsumption(true)
+                .WithEpochInterruption(true)
         );
+
+        /// <summary>
+        /// A runaway (e.g. infinite-looping) Hygge program would otherwise hang
+        /// forever on the single shared <see cref="WasmExecutionThread"/>,
+        /// wedging every other pending/future Wasm call in the process. Exactly
+        /// one of two mechanisms bounds a given run: a fuel budget (consumed
+        /// deterministically per executed instruction - reproducible, same trap
+        /// point every time) or an epoch-based wall-clock timeout (a background
+        /// timer ticks the shared engine's epoch; the run traps once its
+        /// deadline is reached). Wasmtime requires both to be enabled at the
+        /// engine level regardless (the engine is a shared singleton - see
+        /// above - so its Config can't vary per run), so the mechanism that
+        /// isn't chosen for a given run is neutralised with an effectively
+        /// unlimited budget instead of actually being disabled.
+        /// </summary>
+        private const int EpochTickMs = 50;
+
+        /// Ticks at 50ms is ~1.5 million years - far beyond any process's
+        /// lifetime, so this is "never" for the mechanism not in use, without
+        /// risking an unsigned overflow (SetEpochDeadline adds this to the
+        /// current epoch) the way ulong.MaxValue would.
+        private const ulong UnlimitedTicks = 1_000_000_000_000UL;
+
+        private static readonly System.Threading.Timer _epochTicker = new System.Threading.Timer(
+            _ => _sharedEngine.IncrementEpoch(),
+            null,
+            EpochTickMs,
+            EpochTickMs
+        );
+
+        private const ulong DefaultFuel = 100_000_000;
+
+        /// Null means "not the active mechanism for this run" - set to an
+        /// effectively unlimited budget in RunTarget instead of the real one.
+        private readonly ulong? _fuel;
+        private readonly int? _timeoutMs;
 
         private readonly Linker _linker;
         private readonly Store _store;
@@ -37,11 +75,29 @@ namespace WasmTimeDriver
         private readonly bool debug = false;
         private readonly bool output = false;
 
-        public WasmVM(bool debug = false, bool output = false)
+        // ponytail: default fuel budget is a rough order-of-magnitude guess, not a
+        // measured figure. Tune via the constructor if it trips on legitimately heavy
+        // programs or is too generous.
+        //
+        // fuel and timeoutMs are mutually exclusive: pass at most one. If both are
+        // given, fuel wins. If neither is given, fuel with the default budget is used.
+        public WasmVM(bool debug = false, bool output = false, ulong? fuel = null, int? timeoutMs = null)
         {
 
             this.debug = debug;
             this.output = output;
+            if (fuel is not null)
+            {
+                this._fuel = fuel;
+            }
+            else if (timeoutMs is not null)
+            {
+                this._timeoutMs = timeoutMs;
+            }
+            else
+            {
+                this._fuel = DefaultFuel;
+            }
             this._allocator = new MemoryAllocator(1, debug);
 
             _store = new Store(_sharedEngine);
@@ -324,6 +380,10 @@ namespace WasmTimeDriver
             // run the code
             try
             {
+                _store.Fuel = _fuel ?? ulong.MaxValue;
+                // ticks are EpochTickMs apart, so this many ticks from now is roughly _timeoutMs away
+                _store.SetEpochDeadline(_timeoutMs is int t ? (ulong)Math.Max(1, t / EpochTickMs) : UnlimitedTicks);
+
                 function.Invoke();
 
                 // exit code is null if the function does not return anything
@@ -336,6 +396,18 @@ namespace WasmTimeDriver
                 {
                     if (debug) Console.WriteLine("No exit code found");
                 }
+            }
+            catch (TrapException te) when (te.Type == TrapCode.OutOfFuel)
+            {
+                // program ran out of its fuel budget instead of failing on its own
+                if (debug) Console.WriteLine($"warn: execution exceeded its {_fuel} fuel budget and was interrupted");
+                return 42;
+            }
+            catch (TrapException te) when (te.Type == TrapCode.Interrupt)
+            {
+                // program ran longer than the timeout instead of failing on its own
+                if (debug) Console.WriteLine($"warn: execution exceeded {_timeoutMs}ms timeout and was interrupted");
+                return 42;
             }
             catch
             {

--- a/doc/execution_budget.md
+++ b/doc/execution_budget.md
@@ -1,0 +1,102 @@
+# Execution budget (fuel or epoch interruption)
+
+Before this, nothing bounded how long a compiled Hygge program could run. A
+runaway or infinite loop wasn't just a problem for that one run: every Wasm
+call in the process goes through a single shared background thread
+(`WasmExecutionThread`, see [function_pointers.md](function_pointers.md) for
+unrelated context on the same runtime), so a hung program blocked every other
+pending or future `RunFile`/`Run` call in the whole process, not just its own.
+
+## Two mechanisms, pick one per run
+
+Wasmtime offers two unrelated mechanisms for bounding execution, both
+reachable from the `Wasmtime` NuGet package (v44, the version this repo
+pins). Exactly one governs a given run:
+
+- **Fuel** (`Config.WithFuelConsumption`, `Store.Fuel`) — a deterministic,
+  instruction-based budget. Same program + same fuel always traps at the same
+  point on any machine, which is valuable for reproducibility (e.g. tests,
+  grading). This is the default when neither is specified.
+- **Epoch interruption** (`Config.WithEpochInterruption`,
+  `Engine.IncrementEpoch`, `Store.SetEpochDeadline`) — a wall-clock-ish
+  timeout, driven by a background timer that ticks a shared counter every
+  `EpochTickMs` (50ms). Maps onto "kill it after N seconds," which fuel can't
+  express directly, but isn't reproducible: the same program can trap at a
+  different point depending on machine speed and scheduling.
+
+## Implementation
+
+In [`WasmVM.cs`](../WasmTimeDriver/WasmVM.cs):
+
+- The shared `Engine`'s `Config` has both `.WithFuelConsumption(true)` and
+  `.WithEpochInterruption(true)`. Both must be enabled at the engine level
+  regardless of which one a given run actually uses — the engine is a
+  process-wide singleton (see the class doc comment on why), so its `Config`
+  can't vary per run.
+- `WasmVM` takes nullable `fuel` and `timeoutMs` constructor parameters
+  (both default `null`). They're mutually exclusive: if `fuel` is given, it
+  wins even if `timeoutMs` is also given; if only `timeoutMs` is given, that
+  governs; if neither is given, fuel with the default budget
+  (`100_000_000`, a rough order-of-magnitude guess, not a measured figure —
+  see the `ponytail:` comment at the constructor) is used.
+- Before invoking the target function, `RunTarget` sets **both**
+  `_store.Fuel` and `_store.SetEpochDeadline(...)` regardless — the one that
+  isn't the chosen mechanism gets an effectively unlimited value
+  (`ulong.MaxValue` for fuel; a constant `UnlimitedTicks` for epoch, chosen
+  to avoid the unsigned-overflow risk `SetEpochDeadline(ulong.MaxValue)`
+  would carry, since it adds the value to the current epoch rather than
+  treating it as absolute) so it can't realistically trip.
+- Each trap is caught and distinguished by `TrapException.Type`:
+  `TrapCode.OutOfFuel` vs. `TrapCode.Interrupt`, separate from a normal
+  program trap (`TrapCode.Unreachable`, from `assert`/array-bounds/etc.).
+  All three still return exit code 42, same as any other trap, so no
+  caller's pass/fail contract changed — the only difference is which
+  debug-mode log message identifies which budget was hit.
+
+## Example
+
+```csharp
+var vm1 = new WasmVM(debug: true, fuel: 1_000_000);
+vm1.RunWatString(watForAnInfiniteLoop, "t1");
+// -> "warn: execution exceeded its 1000000 fuel budget and was interrupted"
+
+var vm2 = new WasmVM(debug: true, timeoutMs: 500);
+vm2.RunWatString(watForAnInfiniteLoop, "t2");
+// -> "warn: execution exceeded 500ms timeout and was interrupted"
+
+var vm3 = new WasmVM(debug: true, fuel: 1_000_000, timeoutMs: 60_000);
+vm3.RunWatString(watForAnInfiniteLoop, "t3");
+// fuel wins when both are given:
+// -> "warn: execution exceeded its 1000000 fuel budget and was interrupted"
+```
+
+All three return exit code 42 in well under a second instead of hanging
+forever. A normal, non-runaway program (e.g.
+`examples/hygge/rec-simple.hyg`) runs to completion under the default fuel
+budget without tripping it.
+
+## CLI
+
+Both are exposed on the `compile --execute`/`-e` and `wasm` verbs via
+`--fuel <n>` and `--timeout <ms>` ([CmdLine.fs](../src/CmdLine.fs));
+`makeWasmVM` in [Program.fs](../src/Program.fs) just forwards the two
+`Option`s straight through to `WasmVM`'s nullable parameters, so the
+mutual-exclusion rule lives in exactly one place (the `WasmVM` constructor).
+This also fixed a pre-existing gap where the `-e` path built a bare
+`WasmVM()`, so `-v`/`--verbose` never reached it and no debug message was
+ever visible from the CLI.
+
+```sh
+hyggec -v -e --fuel 1000000 myprogram.hyg
+# -> "warn: execution exceeded its 1000000 fuel budget and was interrupted"
+
+hyggec -v -e --timeout 60000 myprogram.hyg
+# -> governed by the timeout instead; fuel is neutralised for this run
+```
+
+## Known gaps / open items
+
+- The default fuel budget (`100_000_000`) is a guess, not tuned against real
+  Hygge programs of varying size — it may need adjusting if it turns out too
+  generous (slow to catch a hang) or too tight (trips on legitimately heavy
+  recursion/loops).

--- a/src/CmdLine.fs
+++ b/src/CmdLine.fs
@@ -123,6 +123,12 @@ type CompilerOptions = {
 
     [<Option('T', "Compilation Target", HelpText="Wasm = 0, RISC-V = 1; defualt: 0")>]
     target: CompilationTarget
+
+    [<Option("fuel", HelpText="With --execute: Wasm fuel budget (an instruction-based, deterministic execution limit) before the program is interrupted. (Default: 100000000)")>]
+    Fuel: Option<uint64>
+
+    [<Option("timeout", HelpText="With --execute: Wasm execution wall-clock timeout in milliseconds before the program is interrupted. (Default: 5000)")>]
+    Timeout: Option<int>
 }
 
 
@@ -162,6 +168,12 @@ type WasmTimeLaunchOptions = {
 
     [<Option('O', "optimize", HelpText="Optimization level (default: 0, i.e. no optimizations, partial evaluation: 1, copy propagation: 2, peephole: 3, all: 4 or more)")>]
     Optimize: uint
+
+    [<Option("fuel", HelpText="Wasm fuel budget (an instruction-based, deterministic execution limit) before the program is interrupted. (Default: 100000000)")>]
+    Fuel: Option<uint64>
+
+    [<Option("timeout", HelpText="Wasm execution wall-clock timeout in milliseconds before the program is interrupted. (Default: 5000)")>]
+    Timeout: Option<int>
 }
 
 

--- a/src/Program.fs
+++ b/src/Program.fs
@@ -183,6 +183,12 @@ let handelOutputFile (outFile: string option, asm) =
         printf $"%O{asm}"
         0 // Success!
 
+/// Build a WasmVM from '--fuel'/'--timeout'. The two are mutually exclusive
+/// (WasmVM prefers fuel if both are given, and falls back to a default fuel
+/// budget if neither is given) - see the WasmVM constructor.
+let makeWasmVM (verbose: bool) (fuel: uint64 option) (timeout: int option) : WasmVM =
+    WasmVM(debug = verbose, fuel = Option.toNullable fuel, timeoutMs = Option.toNullable timeout)
+
 let compileRISCV (opt: CmdLine.CompilerOptions) tast =
     let asm =
         if (opt.ANF) then
@@ -301,7 +307,7 @@ let internal compile (opt: CmdLine.CompilerOptions) : int =
             if opt.Execute then
                 Log.debug $"WASM code: %s{asm}"
                 Console.WriteLine $"Running WASM VM"
-                let vm = WasmVM()
+                let vm = makeWasmVM opt.Verbose opt.Fuel opt.Timeout
                 let res = vm.RunWatString(asm, opt.File)
                 Console.WriteLine $"WASM VM result: %O{res}"
 
@@ -366,7 +372,7 @@ let internal launchRARS (opt: CmdLine.RARSLaunchOptions) : int =
 /// options. Return 0 in case of success, and non-zero in case of error.
 let internal launchWasmTime (opt: CmdLine.WasmTimeLaunchOptions) : int =
 
-    let vm = WasmVM(opt.Verbose)
+    let vm = makeWasmVM opt.Verbose opt.Fuel opt.Timeout
     Console.WriteLine("Running file: " + opt.File)
     let res = vm.RunFile(opt.File)
     Console.WriteLine($"return value {res.ToString()}")


### PR DESCRIPTION
## Summary
- `WasmVM` now bounds every run with exactly one of two Wasmtime mechanisms, chosen via nullable `fuel`/`timeoutMs` constructor parameters (fuel wins if both given; a default fuel budget of 100,000,000 is used if neither is given):
  - **Fuel** (`Config.WithFuelConsumption`, `Store.Fuel`) — a deterministic, instruction-based budget; same program + same budget always traps at the same point on any machine.
  - **Epoch interruption** (`Config.WithEpochInterruption`, `Engine.IncrementEpoch` via a 50ms background timer, `Store.SetEpochDeadline`) — a wall-clock-ish timeout.
- Both features must stay enabled at the engine level (it's a process-wide shared singleton — see the class doc comment), so whichever mechanism isn't chosen for a run is neutralized with an effectively unlimited budget instead of actually disabled. Uses a dedicated `UnlimitedTicks` constant rather than `ulong.MaxValue` for the epoch case, since `SetEpochDeadline` adds its argument to the current epoch and `ulong.MaxValue` would silently overflow.
- Each resulting trap is caught and distinguished via `TrapException.Type` (`TrapCode.OutOfFuel` / `TrapCode.Interrupt`), separate from a normal program trap (`TrapCode.Unreachable`). All still return exit code 42, same as any other trap, so no caller's pass/fail contract changed.
- Exposed on the CLI: `--fuel <n>` / `--timeout <ms>` on the `compile --execute`/`-e` and `wasm` verbs ([CmdLine.fs](../../blob/execution-budget/src/CmdLine.fs)), wired through a shared `makeWasmVM` helper in [Program.fs](../../blob/execution-budget/src/Program.fs).
- Along the way, fixed a pre-existing gap where the `-e` path built a bare `WasmVM()`, so `-v`/`--verbose` never reached it and no debug message was ever visible from the CLI.
- Added [doc/execution_budget.md](../../blob/execution-budget/doc/execution_budget.md) describing the design, the two mechanisms, and the mutual-exclusion rule.

## Why
Every Wasm call in this project is funneled through a single shared background thread (`WasmExecutionThread`). A runaway or infinite-looping Hygge program didn't just hang its own run — it wedged every other pending or future Wasm call in the whole process, with no way to recover short of killing the process. This gives every run a bounded budget so a hang becomes a catchable trap instead.

## Test plan
- [x] `dotnet build hyggec.fsproj` — builds clean.
- [x] `dotnet test` — full suite passes (1407/1407).
- [x] Manually verified via the CLI on an infinite `while(true)` program: `--fuel` alone, `--timeout` alone, both given (fuel wins), and neither given (default fuel) all interrupt in well under a second instead of hanging, each with the correct debug-mode message.
- [x] Verified a normal, non-runaway program (`examples/hygge/rec-simple.hyg`) still runs to completion under the default fuel budget without tripping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)