### PR TITLE
Fill array constructors with bulk memory.copy instead of a per-element loop

### DIFF
--- a/WGF/Instructions.fs
+++ b/WGF/Instructions.fs
@@ -108,9 +108,10 @@ type Wasm =
     // memory instr
     // | MemoryInit of int * int * int
     // | DataDrop of int
-    // | MemoryCopy of int * int
-    // | MemoryFill_ of int * int * int
-    // | MemoryFill
+    /// bulk-memory: copies 'size' bytes from 'src' to 'dest'. Operand order: dest, src, size.
+    | MemoryCopy of Wasm Commented list
+    /// bulk-memory: fills 'size' bytes at 'dest' with the (byte-sized) 'value'. Operand order: dest, value, size.
+    | MemoryFill of Wasm Commented list
     /// Block Instruction
     /// label * result type * instrs
     | Block of Label * ValueType list * list<Commented<Wasm>>

--- a/WGF/WatGen.fs
+++ b/WGF/WatGen.fs
@@ -270,9 +270,8 @@ let instrLabel i =
     | RefFunc(_) -> "ref.func"
     // | MemoryInit(_, _, _) -> "memory.init"
     // | DataDrop(_) -> "data.drop"
-    // | MemoryCopy(_, _) -> "memory.copy"
-    // | MemoryFill_(_, _, _) -> "memory.fill"
-    // | MemoryFill -> "memory.fill"
+    | MemoryCopy(_) -> "memory.copy"
+    | MemoryFill(_) -> "memory.fill"
     | MemoryGrow(_) -> "memory.grow"
     | MemorySize -> "memory.size"
     | StructNew(_, _) -> "struct.new"
@@ -600,6 +599,8 @@ let generateText (instrs: Wasm Commented list) (style: WritingStyle) =
             | I32Store instrs
             | F32Store instrs
             | MemoryGrow instrs
+            | MemoryFill instrs
+            | MemoryCopy instrs
             | Drop instrs
             | StructNew(_, instrs)
             | I32Add instrs when style = Folded ->
@@ -616,6 +617,8 @@ let generateText (instrs: Wasm Commented list) (style: WritingStyle) =
             | StructNew(_, instrs)
             | Drop instrs
             | MemoryGrow instrs
+            | MemoryFill instrs
+            | MemoryCopy instrs
             | F32Sqrt instrs
             | I32GeS instrs
             | F32Ge instrs

--- a/doc/bulk_memory_array_fill.md
+++ b/doc/bulk_memory_array_fill.md
@@ -1,0 +1,78 @@
+# Bulk memory: filling array constructors with memory.copy
+
+`array(length, value)` (the linear-memory allocation strategies — `External`
+and `Internal`; WasmGC's `Heap` strategy already fills in one native
+`array.new` instruction and isn't affected by this) used to fill every
+element with its own `i32.store`/`f32.store` in a hand-written Wasm loop —
+one store instruction per element, O(n) for an array of length n. The code
+even had a `// TODO: optimize loop` sitting next to it.
+
+## Why not memory.fill
+
+Wasm's `memory.fill (dest) (value) (size)` only repeats a single **byte**
+across a range — it can't express an arbitrary 4-byte `i32`/`f32` element
+value (e.g. filling with `42` would need the byte pattern `2A 00 00 00`
+repeated, which isn't what `memory.fill` does; it would repeat `2A 2A 2A 2A`
+instead). It only works, as-is, for the specific case of zero-initialization.
+Real Hygge programs construct arrays with plenty of non-zero constants
+(`array(n, 42)`, `array(n, 1994)`, `array(n, temp)`, ...), so a zero-only
+fast path would miss most of what's actually out there in this repo's own
+test suite.
+
+## What was done instead: memory.copy with doubling
+
+In [`WasmCodegen.fs`](../src/wasm/WasmCodegen.fs), the `Array(length, data)`
+case now:
+
+1. Writes the single `data` element once, at index 0.
+2. Repeatedly calls `memory.copy(dest, src, size)` to duplicate the
+   already-written prefix onto the immediately following, not-yet-written
+   region — doubling the filled portion each time (the last iteration is
+   clamped to whatever's left with a `min(copied, length - copied)`, so it
+   also handles lengths that aren't a power of two).
+
+This takes O(log n) `memory.copy` calls instead of O(n) individual stores,
+works for **any** element value (constant or computed) since it's just
+copying bytes that are already correct rather than re-deriving them, and
+needs no type-specific handling beyond what already existed (`storeInstr`
+still picks `i32.store` vs `f32.store` for the single first-element write).
+
+## IR/printer additions
+
+`MemoryCopy` and `MemoryFill` (the latter added now for parity/future use,
+not currently emitted anywhere) were added to the shared Wasm IR
+([`WGF/Instructions.fs`](../WGF/Instructions.fs)) and wired into the text
+printer ([`WGF/WatGen.fs`](../WGF/WatGen.fs)) by joining the existing generic
+"single flat operand list" instruction group that `memory.grow` already used
+— no bespoke printing code needed. Also added to the handful of
+non-exhaustive helper functions that don't have a wildcard fallback and
+would otherwise crash on an unrecognized instruction
+(`WasmPeepholeHelper.countFunctionInstrs`), plus the recursive cases in
+`WasmPeephole.optimizeInstr` and `WasmCodegen.localSubst` (the latter is what
+promotes captured-closure locals to globals — confirmed working via a
+generated `.wat` showing `global.get $chunk`/`global.get $copied` after
+promotion).
+
+## Verified
+
+- Bulk-memory operations work out of the box on Wasmtime 44 (this repo's
+  pinned version) with no `Config` change needed — checked directly against
+  a standalone `memory.fill`/`memory.copy` module before touching the
+  codegen.
+- Full test suite (1407 tests) passes, including the sorting algorithms
+  (`quickSort.hyg`, `mergeSort.hyg`, `bubblesort.hyg`, etc.) that construct
+  and mutate arrays extensively.
+- Manually verified odd, non-power-of-two lengths (7 and 17 elements) with a
+  non-zero fill value, checking every element individually, under both the
+  `External` and `Internal` allocation strategies — exercises the clamped
+  last-chunk path in the doubling loop.
+
+## Known gaps / open items
+
+- `MemoryFill` was added to the IR for parity but isn't used anywhere yet —
+  a genuine zero-initialization fast path (skipping even the first
+  `memory.copy` round) would still be a marginal win on top of this if
+  profiling ever shows it matters.
+- No equivalent change was made for WasmGC's `Heap` strategy, since
+  `array.new` already fills in a single instruction there — nothing to
+  optimize.

--- a/src/wasm/WasmCodegen.fs
+++ b/src/wasm/WasmCodegen.fs
@@ -1252,62 +1252,93 @@ let rec internal doCodegen (env: CodegenEnv) (node: TypedAST) (m: Module) : Modu
                "store pointer to data") ]
 
 
-        // loop that runs length times and stores data in allocated memory
-        let exitl = env.SymbolController.genSymbol $"loop_exit"
-        let beginl = env.SymbolController.genSymbol $"loop_begin"
-        let i = env.SymbolController.genSymbol $"i"
-
         let storeInstr =
             match (expandType data.Env data.Type) with
             | t when (isSubtypeOf data.Env t TInt) -> I32Store
             | t when (isSubtypeOf data.Env t TFloat) -> F32Store
             | _ -> I32Store
 
-        // body should set data in allocated memory
-        // TODO: optimize loop so i just multiply index with 4 and add it to base address
-        let body =
-            // get value to store in allocated memory
-            [ (storeInstr (
-                  [ (Comment "start of loop body", "")
-                    (I32Add(
-                        [ (I32Load([ (LocalGet(Named(structPointerLabel)), "get struct pointer var") ]),
-                           "load data pointer")
-                          (I32Mul(
-                              [
-                                // find offset to element
-                                (LocalGet(Named(i)), "get index")
-                                (I32Const(4), "byte offset") ]
-                           ),
-                           "multiply index with byte offset") ]
-                     ),
-                     "add offset to base address") ] // then offset is on top of stack
-                  @ data'.GetAccCode()
-               ),
-               "store value in elem pos")
-              (Comment "end of loop body", "") ]
+        /// base address of the allocated element data (reloaded on demand, matching
+        /// the convention used throughout this function rather than caching it)
+        let dataPtr =
+            [ (I32Load([ (LocalGet(Named(structPointerLabel)), "get struct pointer var") ]), "load data pointer") ]
 
-        // loop that runs length times and stores data in allocated memory
+        // Fill the array by writing the single 'data' element once, then doubling
+        // the already-written prefix with memory.copy (dest, src, size) - a bulk
+        // memory operation - until it covers the whole array. This takes O(log n)
+        // copies instead of the previous O(n) individual element stores, and,
+        // unlike memory.fill (which can only repeat a single byte), works for any
+        // element value since it just duplicates bytes that are already correct.
+        let copied = env.SymbolController.genSymbol $"copied"
+        let chunk = env.SymbolController.genSymbol $"chunk"
+        let exitl = env.SymbolController.genSymbol $"loop_exit"
+        let beginl = env.SymbolController.genSymbol $"loop_begin"
+
+        let firstElemStore =
+            [ (storeInstr (dataPtr @ data'.GetAccCode()), "store first element") ]
+
+        // remaining = length - copied
+        let remaining =
+            [ (I32Sub(length'.GetAccCode() @ [ (LocalGet(Named(copied)), "get copied") ]), "length - copied") ]
+
+        let computeChunk =
+            [ (LocalSet(
+                  Named(chunk),
+                  [ (If(
+                        [ I32 ],
+                        [ (I32LtS([ (LocalGet(Named(copied)), "get copied") ] @ remaining), "copied < remaining") ],
+                        [ (LocalGet(Named(copied)), "get copied") ],
+                        Some(remaining)
+                     ),
+                     "chunk = min(copied, remaining)") ]
+               ),
+               "set chunk") ]
+
+        let doubleChunk =
+            [ (MemoryCopy(
+                  [ (I32Add(
+                        dataPtr
+                        @ [ (I32Mul([ (LocalGet(Named(copied)), "get copied"); (I32Const(4), "byte offset") ]),
+                             "multiply copied with byte offset") ]
+                     ),
+                     "dest = base + copied*4") ]
+                  @ dataPtr // src = base
+                  @ [ (I32Mul([ (LocalGet(Named(chunk)), "get chunk"); (I32Const(4), "byte offset") ]),
+                       "chunk * 4 bytes") ]
+               ),
+               "duplicate the already-written prefix") ]
+
         let loop =
             C
                 [ Loop(
                       beginl,
                       [], // loops does not return anything
-                      [ (BrIf(exitl, C [ I32Eq(length'.GetAccCode() @ [ (LocalGet(Named i), "get i") ]) ]), "") ]
-                      @ body
+                      [ (BrIf(
+                            exitl,
+                            C [ I32GeS([ (LocalGet(Named(copied)), "get copied") ] @ length'.GetAccCode()) ]
+                         ),
+                         "exit once the whole array is filled") ]
+                      @ computeChunk
+                      @ doubleChunk
                       @ [ (LocalSet(
-                              Named i,
-                              [ (I32Add([ (LocalGet(Named i), "get i"); (I32Const(1), "increment by 1") ]), "add 1 to i") ]
+                              Named(copied),
+                              [ (I32Add([ (LocalGet(Named(copied)), "get copied"); (LocalGet(Named(chunk)), "get chunk") ]),
+                                 "copied += chunk") ]
                            ),
-                           "write to i") ]
+                           "write to copied") ]
                       @ C [ Br beginl ]
                   ) ]
 
-        // block that contains loop and provides a way to exit the loop
         let block: Commented<WGF.Instr.Wasm> list =
-            C [ LocalSet(Named(i), C [ I32Const 0 ]) ] @ C [ (Block(exitl, [], loop)) ]
+            firstElemStore
+            @ C [ LocalSet(Named(copied), C [ I32Const 1 ]) ]
+            @ C [ (Block(exitl, [], loop)) ]
 
         let loopModule =
-            data'.ResetAccCode().AddLocals([ (Some(Label(i)), I32) ]).AddCode(block)
+            data'
+                .ResetAccCode()
+                .AddLocals([ (Some(Label(copied)), I32); (Some(Label(chunk)), I32) ])
+                .AddCode(block)
 
         lengthCheck
         ++ structPointer.AddCode(instr)
@@ -3032,6 +3063,8 @@ let rec localSubst (code: Commented<WGF.Instr.Wasm> list) (var: string) : Commen
     | (F32Store_(align, offset, instrs), c) :: rest ->
         [ (F32Store_(align, offset, localSubst instrs var), c) ] @ localSubst rest var
     | (MemoryGrow(instrs), c) :: rest -> [ (MemoryGrow(localSubst instrs var), c) ] @ localSubst rest var
+    | (MemoryFill(instrs), c) :: rest -> [ (MemoryFill(localSubst instrs var), c) ] @ localSubst rest var
+    | (MemoryCopy(instrs), c) :: rest -> [ (MemoryCopy(localSubst instrs var), c) ] @ localSubst rest var
     | (BrIf(l, instrs), c) :: rest -> [ (BrIf(l, localSubst instrs var), c) ] @ localSubst rest var
     | (Drop(instrs), c) :: rest -> [ (Drop(localSubst instrs var), c) ] @ localSubst rest var
     | (StructNew(l, instrs), c) :: rest -> [ (StructNew(l, localSubst instrs var), c) ] @ localSubst rest var

--- a/src/wasm/WasmPeephole.fs
+++ b/src/wasm/WasmPeephole.fs
@@ -344,6 +344,8 @@ let rec internal optimizeInstr (code: Commented<WGF.Instr.Wasm> list) : (Comment
     | (Drop(instrs), c) :: rest -> (Drop(optimizeInstr instrs), c) :: optimizeInstr rest
 
     | (MemoryGrow(instrs), c) :: rest -> (MemoryGrow(optimizeInstr instrs), c) :: optimizeInstr rest
+    | (MemoryFill(instrs), c) :: rest -> (MemoryFill(optimizeInstr instrs), c) :: optimizeInstr rest
+    | (MemoryCopy(instrs), c) :: rest -> (MemoryCopy(optimizeInstr instrs), c) :: optimizeInstr rest
 
     // no optimization case matched: continue with the rest
     | stmt :: rest ->

--- a/src/wasm/WasmPeepholeHelper.fs
+++ b/src/wasm/WasmPeepholeHelper.fs
@@ -20,6 +20,8 @@ let rec hasSideEffects (instrs: Commented<WGF.Instr.Wasm> list) : bool =
     | (ReturnCallIndirect _, _) :: rest -> true
     | (StructSet _, _) :: rest -> true
     | (ArraySet _, _) :: rest -> true
+    | (MemoryFill _, _) :: rest -> true
+    | (MemoryCopy _, _) :: rest -> true
 
     | (If (_, con, ifTrue, ifFalse), _) :: rest -> 
         hasSideEffects con ||
@@ -213,6 +215,8 @@ let rec countFunctionInstrs (instrs: Commented<Wasm> list) : int =
     | (F32Div(instrs'), _) :: rest -> 1 + (countFunctionInstrs instrs') + countFunctionInstrs rest
     | (Drop(instrs'), _) :: rest -> 1 + (countFunctionInstrs instrs') + countFunctionInstrs rest
     | (MemoryGrow(instrs'), _) :: rest -> 1 + (countFunctionInstrs instrs') + countFunctionInstrs rest
+    | (MemoryFill(instrs'), _) :: rest -> 1 + (countFunctionInstrs instrs') + countFunctionInstrs rest
+    | (MemoryCopy(instrs'), _) :: rest -> 1 + (countFunctionInstrs instrs') + countFunctionInstrs rest
     | (F32Sqrt(instrs'), _) :: rest -> 1 + (countFunctionInstrs instrs') + countFunctionInstrs rest
     | (F32Max(instrs'), _) :: rest -> 1 + (countFunctionInstrs instrs') + countFunctionInstrs rest
     | (F32Min(instrs'), _) :: rest -> 1 + (countFunctionInstrs instrs') + countFunctionInstrs rest


### PR DESCRIPTION
## Summary
- `array(length, value)` (linear-memory allocation strategies — `External`/`Internal`) used to `i32.store`/`f32.store` every element individually in a hand-written Wasm loop, O(n) instructions for n elements — there was even a `// TODO: optimize loop` sitting next to it.
- It now writes the element once at index 0, then repeatedly `memory.copy`s the already-written prefix onto the following region, doubling it each round (clamped on the last round via `min(copied, length - copied)` for non-power-of-two lengths) — O(log n) bulk copies.
- `memory.fill` alone can't do this in general: it only repeats a single **byte**, so it can only express zero-initialization, not arbitrary element values like `array(n, 42)` — which is most of what this repo's own test suite actually constructs. The doubling-copy approach works for any element value (constant or computed), since it duplicates bytes that are already correct instead of re-deriving them.
- Adds `MemoryCopy`/`MemoryFill` (the latter for parity/future use, not emitted yet) to the shared Wasm IR ([`WGF/Instructions.fs`](../../blob/bulk-memory/WGF/Instructions.fs)) and text printer ([`WGF/WatGen.fs`](../../blob/bulk-memory/WGF/WatGen.fs)), reusing the existing generic "single flat operand list" printing path that `memory.grow` already used — no bespoke printing code.
- Adds both to the handful of non-exhaustive helper matches that lack a wildcard fallback and would otherwise crash on an unrecognized instruction (`WasmPeepholeHelper.countFunctionInstrs`), plus the recursive cases in `WasmPeephole.optimizeInstr` and `WasmCodegen.localSubst` (closure-capture promotion — confirmed exercised via a generated `.wat` showing `global.get $chunk`/`global.get $copied`).
- WasmGC's `Heap` allocation strategy is untouched — its `array.new` already fills in one native instruction, nothing to optimize there.
- Adds [`doc/bulk_memory_array_fill.md`](../../blob/bulk-memory/doc/bulk_memory_array_fill.md) describing the design and why `memory.fill` alone wasn't enough.

## Test plan
- [x] `dotnet build hyggec.fsproj` — builds clean.
- [x] `dotnet test` — full suite passes (1407/1407), including the sorting algorithms (`quickSort.hyg`, `mergeSort.hyg`, `bubblesort.hyg`, etc.) that construct and mutate arrays extensively.
- [x] Verified bulk-memory instructions work out of the box on Wasmtime 44 (this repo's pinned version) with no `Config` change, via a standalone `memory.fill`/`memory.copy` module before touching the codegen.
- [x] Manually verified odd, non-power-of-two lengths (7 and 17 elements) with a non-zero fill value, checking every element individually, under both the `External` and `Internal` allocation strategies — exercises the clamped last-chunk path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)