### PR TITLE
Upgrade target framework to .NET 10

### DIFF
--- a/WasmTimeDriver/WasmTimeDriver.csproj
+++ b/WasmTimeDriver/WasmTimeDriver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/hyggec.fsproj
+++ b/hyggec.fsproj
@@ -12,7 +12,7 @@
     <FsLexOutputFolder>src/</FsLexOutputFolder>
     <FsYaccOutputFolder>src/</FsYaccOutputFolder>
     <!-- Build settings -->
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateProgramFile>false</GenerateProgramFile>
     <LangVersion>preview</LangVersion>
     <Title>A didactic compiler for the Hygge programming language producing WebAssembly (Wasm)</Title>

--- a/src/Program.fs
+++ b/src/Program.fs
@@ -168,7 +168,7 @@ let rec internal interpret (opt: CmdLine.InterpreterOptions) : int =
                 else
                     doInterpret tast (opt.LogLevel = Log.LogLevel.debug || opt.Verbose)
 
-let writeOutFile fileName asm =
+let writeOutFile fileName (asm: string) =
     try
         System.IO.File.WriteAllText(fileName, asm)
         0 // Success!


### PR DESCRIPTION
## Summary
- Bumps `hyggec.fsproj` and `WasmTimeDriver/WasmTimeDriver.csproj` from `net8.0` to `net10.0`
- Fixes a resulting build break: `File.WriteAllText` gained a `ReadOnlySpan<char>` overload in .NET 10, making the call in `writeOutFile` ambiguous — annotated the `asm` parameter as `string`
- `WGF/WGF.fsproj` stays on `netstandard2.1` (library target, already compatible)

## Test plan
- [x] `dotnet build` succeeds with 0 errors
- [x] `dotnet run --project hyggec.fsproj -- test` — full suite passes (1407 passed, 0 failed, 0 errored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)